### PR TITLE
Add Output Vector Editing paper (Hakimi et al. 2026)

### DIFF
--- a/index.html
+++ b/index.html
@@ -698,6 +698,50 @@
             <button onclick="clearFilter()">Show all</button>
         </div>
 
+        <div id="output-vector-editing" class="publication-item" data-tags="interpretability llms" data-paper="output-vector-editing" onclick="openPaperModal('output-vector-editing')">
+            <h3>Output Vector Editing for Memorization Mitigation in Large Language Models</h3>
+            <div class="publication-authors">Ahmad Dawar Hakimi, Kaiwei Lei, Isabelle Augenstein, Hinrich Schütze</div>
+            <div class="publication-venue">arXiv preprint, 2026</div>
+            <details class="publication-abstract" onclick="event.stopPropagation()">
+                <summary>Abstract</summary>
+                <p>Large language models memorize and reproduce sequences from their training data, creating privacy, copyright, and security risks. Existing neuron-level mitigation methods equate editing with zeroing out neuron activations, but the activation only controls whether a neuron engages; the output vector is what writes to the residual stream and, through superposition, encodes multiple features. We propose output vector editing, a constrained-optimization weight edit that locates a small set of MLP neurons responsible for a memorized continuation and minimally modifies their output vectors to introduce a distractor in vocabulary space, redirecting their residual-stream contributions while leaving activations unchanged. Evaluating on four models from 360M to 7B parameters (SmolLM-360M, OLMo-1B, OLMo-7B, Llama2-7B), we center on OLMo-7B (whose open weights and pretraining corpus enable systematic mining) and mine 6831 memorized sequences, achieving up to 87.9% suppression. The 2.7× gap over zero ablation on the same located neurons shows the suppression comes from the output-vector edit, not localization alone. Four edit modes span a spectrum from aggressive suppression to minimal redirection; in ensemble they cover 96.5% of memorized sequences, while our recommended single-mode configuration reaches 81.5% with no catastrophic locality failures. We further identify a mechanistic boundary at ~14% of sequences unreachable by MLP-only editing; while these failures are not attention-driven overall, ablating the top contributing attention heads recovers 60–64% of them, with stronger recovery on continuations that copy tokens from the prefix, positioning attention as a complementary fallback rather than a primary mechanism. Edit mode ordering and the success-locality trade-off transfer across all four models, with success rates scaling with model size rather than family.</p>
+            </details>
+            <div class="publication-tags">
+                <span class="pub-tag">interpretability</span>
+                <span class="pub-tag">llms</span>
+                <span class="pub-keyword">output vector editing</span>
+                <span class="pub-keyword">memorization mitigation</span>
+                <span class="pub-keyword">LLM memorization</span>
+                <span class="pub-keyword">neuron editing</span>
+                <span class="pub-keyword">MLP neurons</span>
+                <span class="pub-keyword">weight editing</span>
+                <span class="pub-keyword">residual stream</span>
+                <span class="pub-keyword">mechanistic interpretability</span>
+            </div>
+            <script type="application/ld+json">
+            {
+                "@context": "https://schema.org",
+                "@type": "ScholarlyArticle",
+                "headline": "Output Vector Editing for Memorization Mitigation in Large Language Models",
+                "author": [
+                    {"@type": "Person", "name": "Ahmad Dawar Hakimi"},
+                    {"@type": "Person", "name": "Kaiwei Lei"},
+                    {"@type": "Person", "name": "Isabelle Augenstein"},
+                    {"@type": "Person", "name": "Hinrich Schütze"}
+                ],
+                "datePublished": "2026",
+                "publisher": {"@type": "Organization", "name": "arXiv"},
+                "isPartOf": "arXiv preprint",
+                "abstract": "Large language models memorize and reproduce sequences from their training data. We propose output vector editing, a constrained-optimization weight edit that locates a small set of MLP neurons responsible for a memorized continuation and minimally modifies their output vectors to introduce a distractor in vocabulary space, redirecting their residual-stream contributions while leaving activations unchanged. On OLMo-7B we mine 6831 memorized sequences and achieve up to 87.9% suppression, with the method transferring across SmolLM-360M, OLMo-1B, OLMo-7B, and Llama2-7B.",
+                "keywords": ["output vector editing", "memorization mitigation", "LLM memorization", "neuron editing", "MLP neurons", "weight editing", "residual stream", "mechanistic interpretability", "superposition", "knowledge localization", "constrained optimization", "privacy", "copyright", "SmolLM", "OLMo", "Llama-2", "large language models"],
+                "url": "https://adhakimi.github.io/#output-vector-editing",
+                "sameAs": [
+                    "https://arxiv.org/abs/2606.18767"
+                ]
+            }
+            </script>
+        </div>
+
         <div id="humans-in-the-loop-llm-annotation" class="publication-item" data-tags="active-learning llms" data-paper="paper0" onclick="openPaperModal('paper0')">
             <h3>Do We Still Need Humans in the Loop? Comparing Human and LLM Annotation in Active Learning for Hostility Detection</h3>
             <div class="publication-authors">Ahmad Dawar Hakimi, Lea Hirlimann, Isabelle Augenstein, Hinrich Schütze</div>
@@ -1142,6 +1186,15 @@
     <script>
         // Paper data with real abstracts and links
         const paperData = {
+            'output-vector-editing': {
+                title: "Output Vector Editing for Memorization Mitigation in Large Language Models",
+                authors: "Ahmad Dawar Hakimi, Kaiwei Lei, Isabelle Augenstein, Hinrich Schütze",
+                venue: "arXiv preprint, 2026",
+                abstract: "Large language models memorize and reproduce sequences from their training data, creating privacy, copyright, and security risks. Existing neuron-level mitigation methods equate editing with zeroing out neuron activations, but the activation only controls whether a neuron engages; the output vector is what writes to the residual stream and, through superposition, encodes multiple features. We propose output vector editing, a constrained-optimization weight edit that locates a small set of MLP neurons responsible for a memorized continuation and minimally modifies their output vectors to introduce a distractor in vocabulary space, redirecting their residual-stream contributions while leaving activations unchanged. Evaluating on four models from 360M to 7B parameters (SmolLM-360M, OLMo-1B, OLMo-7B, Llama2-7B), we center on OLMo-7B (whose open weights and pretraining corpus enable systematic mining) and mine 6831 memorized sequences, achieving up to 87.9% suppression. The 2.7× gap over zero ablation on the same located neurons shows the suppression comes from the output-vector edit, not localization alone. Four edit modes span a spectrum from aggressive suppression to minimal redirection; in ensemble they cover 96.5% of memorized sequences, while our recommended single-mode configuration reaches 81.5% with no catastrophic locality failures. We further identify a mechanistic boundary at ~14% of sequences unreachable by MLP-only editing; while these failures are not attention-driven overall, ablating the top contributing attention heads recovers 60–64% of them, with stronger recovery on continuations that copy tokens from the prefix, positioning attention as a complementary fallback rather than a primary mechanism. Edit mode ordering and the success-locality trade-off transfer across all four models, with success rates scaling with model size rather than family.",
+                links: [
+                    { text: "📝 arXiv", url: "https://arxiv.org/abs/2606.18767" }
+                ]
+            },
             paper0: {
                 title: "Do We Still Need Humans in the Loop? Comparing Human and LLM Annotation in Active Learning for Hostility Detection",
                 authors: "Ahmad Dawar Hakimi, Lea Hirlimann, Isabelle Augenstein, Hinrich Schütze",


### PR DESCRIPTION
## Summary
Adds *Output Vector Editing for Memorization Mitigation in Large Language Models* (Hakimi, Lei, Augenstein, Schütze, [arXiv:2606.18767](https://arxiv.org/abs/2606.18767)) as the newest publication.

Follows the same enriched pattern as the other 9 papers:
- Stable anchor `#output-vector-editing`
- Inline `<details>` abstract (1,889 chars) visible to no-JS crawlers
- 8 visible keyword chips + 9 JSON-LD-only extras (17 total keywords)
- Schema.org `ScholarlyArticle` JSON-LD with author list and `sameAs` arXiv link
- Matching `paperData` entry so the paper modal opens

## Verified locally
- 10 publication items now render (was 9); new paper appears at top
- 10 JSON-LD blocks parse as valid `ScholarlyArticle`
- Interpretability filter now highlights 4 papers (was 3), correct set
- Modal opens for the new paper with correct title

🤖 Generated with [Claude Code](https://claude.com/claude-code)